### PR TITLE
Add TilemapLoader

### DIFF
--- a/gamejam.xcodeproj/project.pbxproj
+++ b/gamejam.xcodeproj/project.pbxproj
@@ -9,6 +9,7 @@
 /* Begin PBXBuildFile section */
 		C81B962B273D85E500249A13 /* Player.swift in Sources */ = {isa = PBXBuildFile; fileRef = C81B962A273D85E500249A13 /* Player.swift */; };
 		C8338380273D8DC300B78B63 /* level_1.json in Resources */ = {isa = PBXBuildFile; fileRef = C833837F273D8DC300B78B63 /* level_1.json */; };
+		C8338382273D9C4D00B78B63 /* TilemapLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8338381273D9C4D00B78B63 /* TilemapLoader.swift */; };
 		C84E7473273CDBFF001CA089 /* SpriteSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = C84E7472273CDBFF001CA089 /* SpriteSheet.swift */; };
 		C880B0B1273A2B6300590586 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C880B0B0273A2B6300590586 /* AppDelegate.swift */; };
 		C880B0B7273A2B6300590586 /* GameScene.swift in Sources */ = {isa = PBXBuildFile; fileRef = C880B0B6273A2B6300590586 /* GameScene.swift */; };
@@ -20,6 +21,7 @@
 /* Begin PBXFileReference section */
 		C81B962A273D85E500249A13 /* Player.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Player.swift; sourceTree = "<group>"; };
 		C833837F273D8DC300B78B63 /* level_1.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = level_1.json; sourceTree = "<group>"; };
+		C8338381273D9C4D00B78B63 /* TilemapLoader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TilemapLoader.swift; sourceTree = "<group>"; };
 		C84E7472273CDBFF001CA089 /* SpriteSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpriteSheet.swift; sourceTree = "<group>"; };
 		C880B0AD273A2B6300590586 /* gamejam.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = gamejam.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		C880B0B0273A2B6300590586 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
@@ -69,6 +71,7 @@
 				C880B0BC273A2B6400590586 /* Main.storyboard */,
 				C880B0BF273A2B6400590586 /* gamejam.entitlements */,
 				C81B962A273D85E500249A13 /* Player.swift */,
+				C8338381273D9C4D00B78B63 /* TilemapLoader.swift */,
 			);
 			path = gamejam;
 			sourceTree = "<group>";
@@ -156,6 +159,7 @@
 				C880B0B9273A2B6300590586 /* ViewController.swift in Sources */,
 				C880B0B7273A2B6300590586 /* GameScene.swift in Sources */,
 				C81B962B273D85E500249A13 /* Player.swift in Sources */,
+				C8338382273D9C4D00B78B63 /* TilemapLoader.swift in Sources */,
 				C880B0B1273A2B6300590586 /* AppDelegate.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/gamejam/GameScene.swift
+++ b/gamejam/GameScene.swift
@@ -1,8 +1,14 @@
 import SpriteKit
 import GameplayKit
 
+protocol GameObject {
+    static func create(_ scene: GameScene, x: Int, y: Int) -> Void
+    func handleKeyDown(_ event: NSEvent) -> Void
+}
+
 class GameScene: SKScene {
     var spritesheet: SpriteSheet?
+    var entities: [GameObject] = []
     
     private var player: Player?
     
@@ -15,13 +21,28 @@ class GameScene: SKScene {
             columns: 13,
             framesize: CGSize(width: 64, height: 64)
         )
-        self.player = Player.create(self)
+        
+        let loader = TilemapLoader(fileNamed: "level_1")
+        loader.forEachLayer({ (l: Layer) in
+            if (l.name == "entities") {
+                // Since we know this is an object layer, let's ignore the Optional
+                l.objects!.forEach({ (obj: Object) in
+                    switch obj.name {
+                    case "player":
+                        // TODO: Offset Y to fit SpriteKit's coordinate system.
+                        Player.create(self, x: obj.x, y: obj.y)
+                    default:
+                        print("unhandled obj: \(obj.name)")
+                    }
+                })
+            }
+        })
     }
     
     override func keyDown(with event: NSEvent) {
-        if let p = self.player {
-            p.handleKeyDown(event)
-        }
+        self.entities.forEach({ e in
+            e.handleKeyDown(event)
+        })
     }
     
     

--- a/gamejam/Player.swift
+++ b/gamejam/Player.swift
@@ -1,21 +1,39 @@
 import SpriteKit
 import GameplayKit
 
-class Player: SKSpriteNode {
-    static func create(_ scene: GameScene) -> Player {
+class Player: SKSpriteNode, GameObject {
+    var cx: Int = 0
+    var cy: Int = 0
+    
+    static func create(_ scene: GameScene, x: Int, y: Int) {
         let image = scene.spritesheet?.getTexture(row: 4, column: 0)
         let player = Player(texture: image)
+        
         // Using .nearest for pixel art
         player.texture?.filteringMode = .nearest
-        player.scale(to: CGSize(width: 64, height: 64))
+        player.size = CGSize(width: 64, height: 64)
         player.anchorPoint = .zero
+        player.setPositionFromPx(x: x, y: y)
+        
         scene.addChild(player)
-        return player
+        scene.entities.append(player)
+    }
+    
+    func setPositionFromPx(x: Int, y: Int) {
+        self.cx = Int(x / Int(self.size.width))
+        self.cy = Int(y / Int(self.size.height))
+        self.setPosition(cx: cx, cy: cy)
+    }
+    
+    func setPosition(cx: Int, cy: Int) {
+        self.cx = cx
+        self.cy = cy
+        self.position.x = CGFloat(cx * Int(self.size.width))
+        self.position.y = CGFloat(cy * Int(self.size.height))
     }
     
     func move(x: Int, y: Int) {
-        self.position.x += CGFloat(x * 64)
-        self.position.y += CGFloat(y * 64)
+        self.setPosition(cx: self.cx + x, cy: self.cy + y)
     }
     
     func handleKeyDown(_ event: NSEvent) {

--- a/gamejam/TilemapLoader.swift
+++ b/gamejam/TilemapLoader.swift
@@ -1,0 +1,89 @@
+import Foundation
+
+struct Object: Codable {
+    var id: Int
+    var gid: Int
+    var name: String
+    var type: String
+    var visible: Bool
+    var rotation: Int
+    var width: Int
+    var height: Int
+    var x: Int
+    var y: Int
+}
+
+struct Tileset: Codable {
+    var firstgid: Int
+    var source: String
+}
+
+struct Layer: Codable {
+    var id: Int
+    var x: Int
+    var y: Int
+    var visible: Bool
+    var name: String
+    var opacity: Int
+    var type: String
+    // type="tilelayer" only
+    var data: [Int]?
+    var height: Int?
+    var width: Int?
+    // type="objectgroup" only
+    var draworder: String?
+    var objects: [Object]?
+}
+
+struct Tilemap: Codable {
+    var compressionlevel: Int
+    var height: Int
+    var infinite: Bool
+    var nextlayerid: Int
+    var nextobjectid: Int
+    var orientation: String
+    var renderorder: String
+    var tiledversion: String
+    var tilewidth: Int
+    var tileheight: Int
+    var width: Int
+    var type: String
+    var tilesets: [Tileset]
+    var layers: [Layer]
+}
+
+enum TilemapError: Error {
+    case fileReadError
+    case serializationError
+}
+
+class TilemapLoader {
+    var fileName: String
+    var tilemap: Tilemap?
+    
+    init(fileNamed: String) {
+        self.fileName = fileNamed
+        self.tilemap = try? loadJson()
+    }
+    
+    func forEachLayer(_ handleLayer: (Layer) -> Void) {
+        if let tilemap = self.tilemap {
+            tilemap.layers.forEach(handleLayer)
+        }
+    }
+    
+    func loadJson() throws -> Tilemap {
+        do {
+            if let path = Bundle.main.path(forResource: self.fileName, ofType: "json") {
+                if let data = NSData(contentsOfFile: path) {
+                    let decoder = JSONDecoder()
+                    return try decoder.decode(Tilemap.self, from: Data(data))
+                }
+            }
+            
+            throw TilemapError.fileReadError
+        } catch {
+            throw TilemapError.serializationError
+        }
+    }
+}


### PR DESCRIPTION
- Add a class that parses JSON from a Tiled map export into a struct.
- This class allows the scene to look at every layer, and from each layer create appropriate background tiles and entities.
- Rewrite `Player` initialization to use the Tiled map position for initialization.

The last commit here introduces some new boilerplate for managing our in-game entities.

Here's what opening one of the levels looks like in [Tiled](https://thorbjorn.itch.io/tiled). Note the two layers, `"background"` and `"entities"`. We'll use those names to differentiate between the object layer (entities, `SKSpriteNode` or `GameObject`), and the tile layer (background, `SKTexture` I think).

![image](https://user-images.githubusercontent.com/3778552/141371456-50b54e61-dc5d-48e7-ab7a-6a19f622c4e4.png)
